### PR TITLE
Add styling rules for sematic tables with thead + tbody elements

### DIFF
--- a/scss/elements/_tables.scss
+++ b/scss/elements/_tables.scss
@@ -1,19 +1,23 @@
 .data-table {
     width: 100%;
     text-align: left;
-    tr {
+
+    //Header Style
+    thead > tr, > tr:first-of-type {
+        background-color: $primary;
+        color: $white;
+        font-weight: $bold;
+    }   
+
+    //Row Styles
+    tbody > tr, >tr {
         @include standard-font;
         &:nth-of-type(even) {
             background-color: $dark5;
         }
         &:nth-of-type(odd) {
             background-color: $dark10;
-        }
-        &:first-of-type {
-            background-color: $primary;
-            color: $white;
-            font-weight: $bold;
-        }                
+        }                   
     }
 
     th, td {


### PR DESCRIPTION
Tweak the style rules for tables to ensure that the header row gets styled correctly with either well formed ( using `thead` and `tbody` elements) or straight up tables 