### PR TITLE
Grid fix

### DIFF
--- a/html_templates/navigation.html
+++ b/html_templates/navigation.html
@@ -39,46 +39,47 @@
             </ul>
         </section>
 
-        <section class="sidebar">
-            <ul class="sidebar__items">
-                <li class="sidebar__item sidebar__item--active"><a href="#">Active Sidebar Item</a></li>
-                <li class="sidebar__item"><a href="#">Sidebar Item</a></li>
-                <li class="sidebar__item"><a href="#">Sidebar Item</a></li>
-                <li class="sidebar__item"><a href="#">Sidebar Item</a></li>
-            </ul>
-            <div class="sidebar__divider"></div>
-            <ul class="sidebar__items">
-                <li class="sidebar__item"><a href="#">Sidebar Item</a></li>
-                <li class="sidebar__item"><a href="#">Sidebar Item</a></li>
-                <li class="sidebar__item"><a href="#">Sidebar Item</a></li>
-                <li class="sidebar__item"><a href="#">Sidebar Item</a></li>
-            </ul>
-        </section>
+        <section class="pagebody">
+            <section class="sidebar">
+                <ul class="sidebar__items">
+                    <li class="sidebar__item sidebar__item--active"><a href="#">Active Sidebar Item</a></li>
+                    <li class="sidebar__item"><a href="#">Sidebar Item</a></li>
+                    <li class="sidebar__item"><a href="#">Sidebar Item</a></li>
+                    <li class="sidebar__item"><a href="#">Sidebar Item</a></li>
+                </ul>
+                <div class="sidebar__divider"></div>
+                <ul class="sidebar__items">
+                    <li class="sidebar__item"><a href="#">Sidebar Item</a></li>
+                    <li class="sidebar__item"><a href="#">Sidebar Item</a></li>
+                    <li class="sidebar__item"><a href="#">Sidebar Item</a></li>
+                    <li class="sidebar__item"><a href="#">Sidebar Item</a></li>
+                </ul>
+            </section>
 
-        <!-- <router-outlet></router-outlet> -->
+            <!-- <router-outlet></router-outlet> -->
 
-        <section class="pagecontent">
-            <div class="wrapper wrapper--inner">
-                <div class="content-full">
-                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris non leo vel enim iaculis aliquam
-                        in eu
-                        nibh. Aliquam efficitur lectus eget massa elementum, ac maximus nunc ornare. Donec laoreet
-                        tincidunt
-                        dui et fermentum. Nunc pulvinar in ligula nec interdum. Nulla rutrum felis justo. Morbi non
-                        malesuada
-                        nunc, eu sodales eros. Proin a lorem faucibus, vestibulum sapien quis, vehicula nisi. Integer
-                        sagittis
-                        leo eu tellus porttitor accumsan non et justo. Donec placerat orci non arcu finibus ultricies.
-                        Orci
-                        varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis sit amet
-                        justo
-                        varius, sodales tellus sit amet, dapibus nunc. Nam auctor placerat ullamcorper. Proin
-                        sollicitudin
-                        viverra odio in tempor. Mauris eu sagittis arcu, eget vestibulum nibh.</p>
+            <section class="pagecontent">
+                <div class="wrapper wrapper--inner">
+                    <div class="content-full">
+                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris non leo vel enim iaculis aliquam
+                            in eu
+                            nibh. Aliquam efficitur lectus eget massa elementum, ac maximus nunc ornare. Donec laoreet
+                            tincidunt
+                            dui et fermentum. Nunc pulvinar in ligula nec interdum. Nulla rutrum felis justo. Morbi non
+                            malesuada
+                            nunc, eu sodales eros. Proin a lorem faucibus, vestibulum sapien quis, vehicula nisi. Integer
+                            sagittis
+                            leo eu tellus porttitor accumsan non et justo. Donec placerat orci non arcu finibus ultricies.
+                            Orci
+                            varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis sit amet
+                            justo
+                            varius, sodales tellus sit amet, dapibus nunc. Nam auctor placerat ullamcorper. Proin
+                            sollicitudin
+                            viverra odio in tempor. Mauris eu sagittis arcu, eget vestibulum nibh.</p>
+                    </div>
                 </div>
-            </div>
+            </section>
         </section>
-
     </div>
 
 </body>

--- a/scss/_components.scss
+++ b/scss/_components.scss
@@ -6,24 +6,34 @@
 @import "elements/tabs";
 
 // Sidebar layout
+// |        Header          |
+// | Sidebar |    Content   |
 
+//Frame gives layout for the header + page
 .pageframe {
     display: grid;
-    grid-template-columns: 300px auto;
+    grid-template-columns: auto;
     grid-template-rows: 60px auto;
     grid-template-areas:
-        "navigation navigation"
-        "sidebar body";
+        "navigation"
+        "content";
     height: 100%;
 }
 
+//Body gives layout for the sidebar + content
+.pagebody {
+    display: grid;    
+    grid-template-columns: 300px auto;
+    grid-template-rows: auto;
+    grid-template-areas: "sidebar" "ui";    
+    height: 100%;    
+}
+
+//Page Content used to position the actual content inside it's grid cell
 .pagecontent {
-    display: grid;
-    grid-area: body;
-    grid-template-columns: repeat(12, 1fr);
-    grid-template-rows: repeat(auto-fit);
     margin: 20px 20px 0 20px;
 }
+
 
 // Wrapper for all main-page content areas
 

--- a/scss/_reset.scss
+++ b/scss/_reset.scss
@@ -46,3 +46,6 @@ table {
 	border-collapse: collapse;
 	border-spacing: 0;
 }
+
+//Burn Angular with Fire
+router-outlet { display: none;}


### PR DESCRIPTION
Change to fix the issue of the grid blowing up with Angular requiring an extra layer of elements.  Wraps the sidebar + content in an wrapper classed with `.pagebody`

Also adds a reset rule to hide the nasty `<router-outlet />` tags that Angular requires in the page